### PR TITLE
add ansible parallel deployment

### DIFF
--- a/private-layer1.yaml
+++ b/private-layer1.yaml
@@ -23,7 +23,7 @@
       set_fact:
         kaia_conf_override:
           RPC_ENABLE: 1
-          RPC_API: kaia,admin,personal,eth,web3,net
+          RPC_API: kaia,admin,personal,eth,web3,net,governance,istanbul
       when: "'en' in group_names"
   roles:
   - { role: kaiaspray-defaults }

--- a/private-layer1.yaml
+++ b/private-layer1.yaml
@@ -8,29 +8,23 @@
   tags:
   - localhost
 
-- hosts: cn
+- hosts: cn,pn,en
   gather_facts: True
-  vars:
-    kaia_node_type: cn
-  roles:
-  - { role: kaiaspray-defaults }
-  - { role: node-init }
-
-- hosts: pn
-  gather_facts: True
-  vars:
-    kaia_node_type: pn
-  roles:
-  - { role: kaiaspray-defaults }
-  - { role: node-init }
-
-- hosts: en
-  gather_facts: True
-  vars:
-    kaia_node_type: en
-    kaia_conf_override:
-      RPC_ENABLE: 1
-      RPC_API: kaia,admin,personal,eth,web3,net
+  strategy: free
+  pre_tasks:
+    - name: Set kaia_node_type variable
+      set_fact:
+        kaia_node_type: >-
+          {{ ('cn' if 'cn' in group_names
+              else 'pn' if 'pn' in group_names
+              else 'en' if 'en' in group_names
+              else 'unknown') | trim }}
+    - name: Set configuration override for en node
+      set_fact:
+        kaia_conf_override:
+          RPC_ENABLE: 1
+          RPC_API: kaia,admin,personal,eth,web3,net
+      when: "'en' in group_names"
   roles:
   - { role: kaiaspray-defaults }
   - { role: node-init }


### PR DESCRIPTION
# Description
Add parallel deployment strategy to Ansible playbook

This PR implements parallel deployment in the Ansible playbook to improve deployment speed and resource utilization.

Key changes:
- Add `strategy: free` for parallel execution
- Consolidate host groups for better management

Fixes #29 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud: GCP
* OS verson: macOS 15.4(24E248)
* Kaia version: v1.0.3
* Ansible version: core 2.18.4
* Terraform version: v1.9.1

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
