### PR TITLE
increase homi test account num

### DIFF
--- a/roles/local-init/defaults/main.yml
+++ b/roles/local-init/defaults/main.yml
@@ -1,5 +1,5 @@
 homi_bin: "{{ bin_dir }}/homi"
 homi_default_options: ""
-homi_test_account_num: 2
+homi_test_account_num: 16
 
 force_create_genesis: False


### PR DESCRIPTION
# Description

This PR increases the default number of homi test accounts from 2 to 16.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
