### PR TITLE
Fix typos in dashboard title and configuration comment

### DIFF
--- a/roles/monitor-init/files/grafana/dashboards/service-chain-overview.json
+++ b/roles/monitor-init/files/grafana/dashboards/service-chain-overview.json
@@ -600,7 +600,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Requets Event Rate",
+      "title": "Request Event Rate",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/roles/node-init/templates/kaia.conf.j2
+++ b/roles/node-init/templates/kaia.conf.j2
@@ -78,7 +78,7 @@ SC_TX_LIMIT={{ kaia_conf.SC_TX_LIMIT | default('1000') }}
 SC_PARENT_OPERATOR_GASLIMIT={{ kaia_conf.SC_PARENT_OPERATOR_GASLIMIT | default('10000000') }}
 SC_CHILD_OPERATOR_GASLIMIT={{ kaia_conf.SC_CHILD_OPERATOR_GASLIMIT | default('10000000') }}
 
-SC_VTRECOVERY={{ kaia_conf.SC_VTRECOVERY| default('1') }} # value trasnfer recovery activation
+SC_VTRECOVERY={{ kaia_conf.SC_VTRECOVERY| default('1') }} # value transfer recovery activation
 SC_VTRECOVERY_INTERVAL={{ kaia_conf.SC_VTRECOVERY_INTERVAL | default('5') }} # recovery interval
 {% endif %}
 {% endif %}


### PR DESCRIPTION


**Description:**
- Corrected a typo in the Grafana dashboard title from "Requets Event Rate" to "Request Event Rate" in `service-chain-overview.json`.
- Fixed a typo in the configuration comment from "trasnfer" to "transfer" in `kaia.conf.j2`.

