### PR TITLE
local: Assign 8551+n and 8651+n

### DIFF
--- a/local-deploy/0_kaia_setup.sh
+++ b/local-deploy/0_kaia_setup.sh
@@ -14,8 +14,8 @@ modifyNNData()
   for ((num = 1; num <= NUM_OF_NODE; num++))
   do
     PORT=$(( 32323 + (PORT_BASE+num-1)*2 ))
-    RPC_PORT=$(( 8551 + (PORT_BASE+num-1)*2 ))
-    WS_PORT=$(( 8551 + (PORT_BASE+num-1)*2 +1 ))
+    RPC_PORT=$(( 8551 + PORT_BASE+num - 1 ))
+    WS_PORT=$(( 8651 + PORT_BASE+num - 1 ))
     PROMETHEUS_PORT=$(( 61001 + PORT_BASE + num - 1))
 
     echo $NODE_TYPE$num ": " $PORT $RPC_PORT $WS_PORT $PROMETHEUS_PORT

--- a/local-deploy/7_monitoring.sh
+++ b/local-deploy/7_monitoring.sh
@@ -11,6 +11,14 @@ mkdir -p monitoring/prometheus
 mkdir -p monitoring/grafana/provisioning/datasources
 mkdir -p monitoring/grafana/provisioning/dashboards
 
+docker_compose() {
+    if docker compose version >/dev/null 2>&1; then
+        docker compose -f ./docker-compose.yml "$@"
+    else
+        docker-compose -f ./docker-compose.yml "$@"
+    fi
+}
+
 # Function to setup Grafana dashboards
 setup_grafana_dashboards() {
   # Get the absolute path of the script directory
@@ -95,13 +103,13 @@ case "$1" in
         generate_prometheus_config
         generate_grafana_config
         setup_grafana_dashboards
-        docker-compose up -d
+        docker_compose up -d
         echo "Prometheus is available at http://localhost:9090"
         echo "Grafana is available at http://localhost:3000 (admin/admin)"
         ;;
     stop)
         echo "Stopping monitoring tools..."
-        docker-compose down
+        docker_compose down
         echo "Monitoring tools stopped"
         ;;
     url)


### PR DESCRIPTION
# Description

- Slightly modify the port assigning logic to be `rpcport=8551+n` and `wsport=8651+n`. This way is easier to remember.
```
cn1 :  32323 8551 8651 61001
pn1 :  32325 8552 8652 61002
en1 :  32327 8553 8653 61003
en2 :  32329 8554 8654 61004
en3 :  32331 8555 8655 61005
```

- Fix docker-compose command. `docker-compose` might not exist in Mac Docker Desktop. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
