### PR TITLE
gcp: support snapshot

### DIFF
--- a/terraform/gcp/modules/kaia-node/main.tf
+++ b/terraform/gcp/modules/kaia-node/main.tf
@@ -4,6 +4,7 @@ resource "google_compute_instance" "this" {
   zone         = var.zone
 
   boot_disk {
+    auto_delete = true
     initialize_params {
       image = lookup(var.boot_disk, "image_id", data.google_compute_image.this.family)
       size  = lookup(var.boot_disk, "boot_disk_size", 20)
@@ -14,7 +15,8 @@ resource "google_compute_instance" "this" {
     for_each = var.compute_disk != null ? [1] : []
 
     content {
-      source = google_compute_disk.this[0].self_link
+      source      = google_compute_disk.this[0].self_link
+      device_name = lookup(var.compute_disk, "name", "data-disk")
     }
   }
 
@@ -40,10 +42,11 @@ resource "google_compute_instance" "this" {
 resource "google_compute_disk" "this" {
   count = var.compute_disk != null ? 1 : 0
 
-  name = lookup(var.compute_disk, "name", null)
-  type = lookup(var.compute_disk, "type", null)
-  zone = lookup(var.compute_disk, "zone", null)
-  size = lookup(var.compute_disk, "size", null)
+  name     = lookup(var.compute_disk, "name", null)
+  type     = lookup(var.compute_disk, "type", null)
+  zone     = lookup(var.compute_disk, "zone", null)
+  size     = lookup(var.compute_disk, "size", null)
+  snapshot = lookup(var.compute_disk, "snapshot", null)
 }
 
 resource "google_compute_address" "this" {

--- a/terraform/gcp/modules/keypair/outputs.tf
+++ b/terraform/gcp/modules/keypair/outputs.tf
@@ -7,5 +7,9 @@ output "ssh_public_key" {
 }
 
 output "ssh_private_key_path" {
-  value = local.private_key_path
+  value = var.create_gcp_key_pair ? var.ssh_private_key_path : var.ssh_existing_private_key_path
+}
+
+output "ssh_key_file_created" {
+  value = var.create_gcp_key_pair ? local_sensitive_file.this[0].id : "existing_key"
 }

--- a/terraform/gcp/modules/private-layer1/locals.tf
+++ b/terraform/gcp/modules/private-layer1/locals.tf
@@ -1,24 +1,44 @@
 locals {
-  cn_options = {
-    count          = lookup(var.cn_options, "count", 4)
-    machine_type   = lookup(var.cn_options, "machine_type", "e2-medium")
-    boot_disk_size = lookup(var.cn_options, "boot_disk_size", 500)
-  }
-
-  pn_options = {
-    count          = lookup(var.pn_options, "count", 4)
-    machine_type   = lookup(var.pn_options, "machine_type", "e2-medium")
-    boot_disk_size = lookup(var.pn_options, "boot_disk_size", 500)
-  }
-
-  en_options = {
-    count          = lookup(var.en_options, "count", 4)
-    machine_type   = lookup(var.en_options, "machine_type", "e2-medium")
-    boot_disk_size = lookup(var.en_options, "boot_disk_size", 500)
+  # Default values
+  defaults = {
+    machine_type = "n2-standard-2"
+    boot_disk_size = 100
+    compute_disk_size = null
+    snapshot_id = null
   }
 
   monitor_options = {
-    machine_type   = lookup(var.monitor_options, "machine_type", "e2-medium")
-    boot_disk_size = lookup(var.monitor_options, "boot_disk_size", 500)
+    machine_type   = lookup(var.monitor_options, "machine_type", local.defaults.machine_type)
+    boot_disk_size = lookup(var.monitor_options, "boot_disk_size", local.defaults.boot_disk_size)
+    compute_disk_size = lookup(var.monitor_options, "compute_disk_size", local.defaults.compute_disk_size)
+    snapshot_id = lookup(var.monitor_options, "snapshot_id", local.defaults.snapshot_id)
   }
+
+  # Generate node options lists - can be used like get_cn_node_options[0]
+  get_cn_node_options = [
+    for i in range(lookup(var.cn_options, "count", 0)) : {
+      machine_type = try(lookup(var.cn_options, "options", {})[tostring(i)].machine_type, lookup(var.cn_options, "machine_type", local.defaults.machine_type))
+      boot_disk_size = try(lookup(var.cn_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.cn_options, "boot_disk_size", local.defaults.boot_disk_size))
+      compute_disk_size = try(lookup(var.cn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.cn_options, "compute_disk_size", local.defaults.compute_disk_size))
+      snapshot_id = try(lookup(var.cn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.cn_options, "snapshot_id", local.defaults.snapshot_id))
+    }
+  ]
+
+  get_pn_node_options = [
+    for i in range(lookup(var.pn_options, "count", 0)) : {
+      machine_type = try(lookup(var.pn_options, "options", {})[tostring(i)].machine_type, lookup(var.pn_options, "machine_type", local.defaults.machine_type))
+      boot_disk_size = try(lookup(var.pn_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.pn_options, "boot_disk_size", local.defaults.boot_disk_size))
+      compute_disk_size = try(lookup(var.pn_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.pn_options, "compute_disk_size", local.defaults.compute_disk_size))
+      snapshot_id = try(lookup(var.pn_options, "options", {})[tostring(i)].snapshot_id, lookup(var.pn_options, "snapshot_id", local.defaults.snapshot_id))
+    }
+  ]
+
+  get_en_node_options = [
+    for i in range(lookup(var.en_options, "count", 0)) : {
+      machine_type = try(lookup(var.en_options, "options", {})[tostring(i)].machine_type, lookup(var.en_options, "machine_type", local.defaults.machine_type))
+      boot_disk_size = try(lookup(var.en_options, "options", {})[tostring(i)].boot_disk_size, lookup(var.en_options, "boot_disk_size", local.defaults.boot_disk_size))
+      compute_disk_size = try(lookup(var.en_options, "options", {})[tostring(i)].compute_disk_size, lookup(var.en_options, "compute_disk_size", local.defaults.compute_disk_size))
+      snapshot_id = try(lookup(var.en_options, "options", {})[tostring(i)].snapshot_id, lookup(var.en_options, "snapshot_id", local.defaults.snapshot_id))
+    }
+  ]
 }

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -145,8 +145,11 @@ resource "null_resource" "cn_disk_mount" {
     if options.compute_disk_size != null
   }
 
+  depends_on = [var.ssh_key_file_created]
+
   triggers = {
     instance_id = module.cn[each.key].instance_link
+    ssh_key_file = var.ssh_key_file_created
   }
 
   provisioner "file" {
@@ -183,8 +186,11 @@ resource "null_resource" "pn_disk_mount" {
     if options.compute_disk_size != null
   }
 
+  depends_on = [var.ssh_key_file_created]
+
   triggers = {
     instance_id = module.pn[each.key].instance_link
+    ssh_key_file = var.ssh_key_file_created
   }
 
   provisioner "file" {
@@ -221,8 +227,11 @@ resource "null_resource" "en_disk_mount" {
     if options.compute_disk_size != null
   }
 
+  depends_on = [var.ssh_key_file_created]
+
   triggers = {
     instance_id = module.en[each.key].instance_link
+    ssh_key_file = var.ssh_key_file_created
   }
 
   provisioner "file" {
@@ -256,8 +265,11 @@ resource "null_resource" "en_disk_mount" {
 resource "null_resource" "monitor_disk_mount" {
   count = try(local.monitor_options.compute_disk_size, null) != null ? 1 : 0
 
+  depends_on = [var.ssh_key_file_created]
+
   triggers = {
     instance_id = module.monitor.instance_link
+    ssh_key_file = var.ssh_key_file_created
   }
 
   provisioner "file" {

--- a/terraform/gcp/modules/private-layer1/main.tf
+++ b/terraform/gcp/modules/private-layer1/main.tf
@@ -1,10 +1,12 @@
 module "cn" {
-  count = local.cn_options.count
+  count = length(local.get_cn_node_options)
 
   source = "../kaia-node"
 
   name         = format("%s-cn-%d", var.name, count.index + 1)
-  machine_type = local.cn_options.machine_type
+  
+  # Get node settings with index-based overrides
+  machine_type = local.get_cn_node_options[count.index].machine_type
 
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
@@ -14,15 +16,16 @@ module "cn" {
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.cn_options.boot_disk_size
+    boot_disk_size = local.get_cn_node_options[count.index].boot_disk_size
   }
 
-  # compute_disk = {
-  #   name = format("%s-cn-%d-disk", var.name, count.index + 1)
-  #   type = "pd-ssd"
-  #   zone = var.zone_list[count.index % length(var.zone_list)]
-  #   size = 100
-  # }
+  compute_disk = local.get_cn_node_options[count.index].compute_disk_size != null ? {
+    name        = format("%s-cn-%d-disk", var.name, count.index + 1)
+    type        = "pd-ssd"
+    zone        = var.zone_list[count.index % length(var.zone_list)]
+    size        = local.get_cn_node_options[count.index].compute_disk_size
+    snapshot    = local.get_cn_node_options[count.index].snapshot_id
+  } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "cn"]
 
@@ -32,12 +35,14 @@ module "cn" {
 }
 
 module "pn" {
-  count = local.pn_options.count
+  count = length(local.get_pn_node_options)
 
   source = "../kaia-node"
 
   name         = format("%s-pn-%d", var.name, count.index + 1)
-  machine_type = local.pn_options.machine_type
+  
+  # Get node settings with index-based overrides
+  machine_type = local.get_pn_node_options[count.index].machine_type
 
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
@@ -47,15 +52,16 @@ module "pn" {
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.pn_options.boot_disk_size
+    boot_disk_size = local.get_pn_node_options[count.index].boot_disk_size
   }
 
-  # compute_disk = {
-  #   name = format("%s-pn-%d-disk", var.name, count.index + 1)
-  #   type = "pd-ssd"
-  #   zone = var.zone_list[count.index % length(var.zone_list)]
-  #   size = 100
-  # }
+  compute_disk = local.get_pn_node_options[count.index].compute_disk_size != null ? {
+    name = format("%s-pn-%d-disk", var.name, count.index + 1)
+    type = "pd-ssd"
+    zone = var.zone_list[count.index % length(var.zone_list)]
+    size = local.get_pn_node_options[count.index].compute_disk_size
+    snapshot = local.get_pn_node_options[count.index].snapshot_id
+  } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "pn"]
 
@@ -65,12 +71,14 @@ module "pn" {
 }
 
 module "en" {
-  count = local.en_options.count
+  count = length(local.get_en_node_options)
 
   source = "../kaia-node"
 
   name         = format("%s-en-%d", var.name, count.index + 1)
-  machine_type = local.en_options.machine_type
+  
+  # Get node settings with index-based overrides
+  machine_type = local.get_en_node_options[count.index].machine_type
 
   subnetwork    = var.subnetwork
   zone          = var.zone_list[count.index % length(var.zone_list)]
@@ -80,15 +88,16 @@ module "en" {
 
   boot_disk = {
     image_id       = var.boot_image_id
-    boot_disk_size = local.en_options.boot_disk_size
+    boot_disk_size = local.get_en_node_options[count.index].boot_disk_size
   }
 
-  # compute_disk = {
-  #   name = format("%s-en-%d-disk", var.name, count.index + 1)
-  #   type = "pd-ssd"
-  #   zone = var.zone_list[count.index % length(var.zone_list)]
-  #   size = 100
-  # }
+  compute_disk = local.get_en_node_options[count.index].compute_disk_size != null ? {
+    name = format("%s-en-%d-disk", var.name, count.index + 1)
+    type = "pd-ssd"
+    zone = var.zone_list[count.index % length(var.zone_list)]
+    size = local.get_en_node_options[count.index].compute_disk_size
+    snapshot = local.get_en_node_options[count.index].snapshot_id
+  } : null
 
   tags = length(var.network_tags) > 0 ? concat(var.network_tags) : ["kaiaspray", "en"]
 
@@ -114,16 +123,166 @@ module "monitor" {
     boot_disk_size = local.monitor_options.boot_disk_size
   }
 
-  # compute_disk = {
-  #   name = format("%s-monitor-disk", var.name)
-  #   type = "pd-ssd"
-  #   zone = var.zone_list[count.index % length(var.zone_list)]
-  #   size = 100
-  # }
+  compute_disk = try(local.monitor_options.compute_disk_size, null) != null ? {
+    name = format("%s-monitor-disk", var.name)
+    type = "pd-ssd"
+    zone = var.zone_list[0]
+    size = local.monitor_options.compute_disk_size
+    snapshot = try(local.monitor_options.snapshot_id, null)
+  } : null
 
   tags = length(var.network_tags) > 0 ? var.network_tags : ["kaiaspray", "monitor"]
 
   metadata = merge(var.metadata, {
     Name = format("%s-monitor", var.name)
   })
+}
+
+# Provisioner for CN nodes with compute disk
+resource "null_resource" "cn_disk_mount" {
+  for_each = {
+    for idx, options in local.get_cn_node_options : idx => options
+    if options.compute_disk_size != null
+  }
+
+  triggers = {
+    instance_id = module.cn[each.key].instance_link
+  }
+
+  provisioner "file" {
+    source   = "${path.module}/mount_disk.sh"
+    destination = "/tmp/mount_disk.sh"
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.cn[each.key].public_ip
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/mount_disk.sh",
+      "sudo /tmp/mount_disk.sh ${format("%s-cn-%d-disk", var.name, each.key + 1)} kcnd"
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.cn[each.key].public_ip
+    }
+  }
+}
+
+# Provisioner for PN nodes with compute disk
+resource "null_resource" "pn_disk_mount" {
+  for_each = {
+    for idx, options in local.get_pn_node_options : idx => options
+    if options.compute_disk_size != null
+  }
+
+  triggers = {
+    instance_id = module.pn[each.key].instance_link
+  }
+
+  provisioner "file" {
+    source   = "${path.module}/mount_disk.sh"
+    destination = "/tmp/mount_disk.sh"
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.pn[each.key].public_ip
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/mount_disk.sh",
+      "sudo /tmp/mount_disk.sh ${format("%s-pn-%d-disk", var.name, each.key + 1)} kpnd"
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.pn[each.key].public_ip
+    }
+  }
+}
+
+# Provisioner for EN nodes with compute disk
+resource "null_resource" "en_disk_mount" {
+  for_each = {
+    for idx, options in local.get_en_node_options : idx => options
+    if options.compute_disk_size != null
+  }
+
+  triggers = {
+    instance_id = module.en[each.key].instance_link
+  }
+
+  provisioner "file" {
+    source   = "${path.module}/mount_disk.sh"
+    destination = "/tmp/mount_disk.sh"
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.en[each.key].public_ip
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/mount_disk.sh",
+      "sudo /tmp/mount_disk.sh ${format("%s-en-%d-disk", var.name, each.key + 1)} kend"
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.en[each.key].public_ip
+    }
+  }
+}
+
+# Provisioner for Monitor node with compute disk
+resource "null_resource" "monitor_disk_mount" {
+  count = try(local.monitor_options.compute_disk_size, null) != null ? 1 : 0
+
+  triggers = {
+    instance_id = module.monitor.instance_link
+  }
+
+  provisioner "file" {
+    source   = "${path.module}/mount_disk.sh"
+    destination = "/tmp/mount_disk.sh"
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.monitor.public_ip
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/mount_disk.sh",
+      "sudo /tmp/mount_disk.sh ${format("%s-monitor-disk", var.name)} monitor"
+    ]
+
+    connection {
+      type        = "ssh"
+      user        = var.user_name
+      private_key = file(var.ssh_private_key_path)
+      host        = module.monitor.public_ip
+    }
+  }
 }

--- a/terraform/gcp/modules/private-layer1/mount_disk.sh
+++ b/terraform/gcp/modules/private-layer1/mount_disk.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Mount GCP disk by disk name to /var/<module_name>, no partitioning
+
+set -e
+
+DISK_NAME="${1:-kaia-helper}"                         # e.g., device_name = "kaia-helper"
+MODULE_NAME="${2:-kaia-helper}"                       # e.g., kcnd, kpnd, kend
+MOUNT_POINT="/var/${MODULE_NAME}"
+# GCP disk path pattern: /dev/disk/by-id/google-{disk_name}
+DISK_PATH="/dev/disk/by-id/google-${DISK_NAME}"
+FILESYSTEM="ext4"
+
+echo "[INFO] Using disk: $DISK_PATH"
+echo "[INFO] Mount point: $MOUNT_POINT"
+echo "[INFO] Module name: $MODULE_NAME"
+
+# Check if disk exists
+if [ ! -L "$DISK_PATH" ]; then
+  echo "[ERROR] Disk not found: $DISK_PATH"
+  echo "[INFO] Available disks:"
+  ls -la /dev/disk/by-id/google-* 2>/dev/null || echo "No google disks found"
+  exit 1
+fi
+
+# Format disk if no filesystem exists
+if ! blkid "$DISK_PATH" &>/dev/null; then
+  echo "[INFO] No filesystem found. Creating $FILESYSTEM on $DISK_PATH"
+  mkfs.$FILESYSTEM "$DISK_PATH"
+else
+  echo "[INFO] Filesystem already exists on $DISK_PATH"
+fi
+
+# Create and mount
+mkdir -p "$MOUNT_POINT"
+mount "$DISK_PATH" "$MOUNT_POINT"
+echo "[INFO] Mounted $DISK_PATH to $MOUNT_POINT"
+
+# Add to /etc/fstab
+if ! grep -q "$DISK_PATH" /etc/fstab; then
+  echo "$DISK_PATH $MOUNT_POINT $FILESYSTEM defaults 0 2" >> /etc/fstab
+  echo "[INFO] fstab entry added"
+fi

--- a/terraform/gcp/modules/private-layer1/outputs.tf
+++ b/terraform/gcp/modules/private-layer1/outputs.tf
@@ -13,3 +13,24 @@ output "en" {
 output "monitor" {
   value = module.monitor
 }
+
+# Outputs for testing locals
+output "defaults" {
+  value = local.defaults
+}
+
+output "get_cn_node_options" {
+  value = local.get_cn_node_options
+}
+
+output "get_pn_node_options" {
+  value = local.get_pn_node_options
+}
+
+output "get_en_node_options" {
+  value = local.get_en_node_options
+}
+
+output "monitor_options" {
+  value = local.monitor_options
+}

--- a/terraform/gcp/modules/private-layer1/variables.tf
+++ b/terraform/gcp/modules/private-layer1/variables.tf
@@ -90,3 +90,15 @@ variable "network_tier" {
   description = "Network tier for external IP addresses (PREMIUM or STANDARD)"
   default     = "PREMIUM"
 }
+
+variable "ssh_private_key_path" {
+  type        = string
+  description = "Path to SSH private key for connecting to instances"
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "user_name" {
+  type        = string
+  description = "User name for SSH login to instances"
+  default     = "core"
+}

--- a/terraform/gcp/modules/private-layer1/variables.tf
+++ b/terraform/gcp/modules/private-layer1/variables.tf
@@ -102,3 +102,8 @@ variable "user_name" {
   description = "User name for SSH login to instances"
   default     = "core"
 }
+
+variable "ssh_key_file_created" {
+  type        = string
+  description = "INTERNAL: Do not set this manually. ID of the created SSH key file for dependency management"
+}

--- a/terraform/gcp/private-layer1/ansible-inventory.tf
+++ b/terraform/gcp/private-layer1/ansible-inventory.tf
@@ -2,7 +2,7 @@ locals {
   ansible_inventory = templatefile(
     "${path.module}/templates/inventory.tftpl",
     {
-      ansible_ssh_private_key_file = module.keypair.ssh_private_key_path
+      ansible_ssh_private_key_file = abspath(module.keypair.ssh_private_key_path)
       user_name                    = var.user_name
       cn                           = try(module.layer1.cn, [])
       pn                           = try(module.layer1.pn, [])

--- a/terraform/gcp/private-layer1/main.tf
+++ b/terraform/gcp/private-layer1/main.tf
@@ -15,6 +15,7 @@ module "layer1" {
   ssh_client_ips = var.ssh_client_ips
   user_name      = var.user_name
   ssh_private_key_path = module.keypair.ssh_private_key_path
+  ssh_key_file_created = module.keypair.ssh_key_file_created
 
   cn_options      = var.cn_options
   pn_options      = var.pn_options

--- a/terraform/gcp/private-layer1/main.tf
+++ b/terraform/gcp/private-layer1/main.tf
@@ -13,6 +13,8 @@ module "layer1" {
 
   boot_image_id  = data.google_compute_image.this.self_link
   ssh_client_ips = var.ssh_client_ips
+  user_name      = var.user_name
+  ssh_private_key_path = module.keypair.ssh_private_key_path
 
   cn_options      = var.cn_options
   pn_options      = var.pn_options
@@ -21,7 +23,10 @@ module "layer1" {
 
   metadata = merge(
     var.metadata,
-    local.default_metadata,
-    { ssh-keys = format("%s:%s %s", var.user_name, trimspace(module.keypair.ssh_public_key), var.user_name) }
+    {
+      Name      = local.name
+      ManagedBy = "terraform"
+      ssh-keys  = format("%s:%s %s", var.user_name, trimspace(module.keypair.ssh_public_key), var.user_name)
+    }
   )
 }

--- a/terraform/gcp/private-layer1/terraform.tfvars
+++ b/terraform/gcp/private-layer1/terraform.tfvars
@@ -6,6 +6,13 @@ name           = "kaiaspray"
 user_name       = "kaia"
 ssh_client_ips = ["0.0.0.0/0"]
 
+#network    = ""
+#subnetwork = ""
+#network_tags = ["ssh"]
+
+# create_gcp_key_pair = false
+# ssh_existing_private_key_path = ""
+# ssh_existing_public_key_path  = ""
 
 deploy_options = {
   kaia_install_mode = "package"

--- a/terraform/gcp/private-layer1/terraform.tfvars
+++ b/terraform/gcp/private-layer1/terraform.tfvars
@@ -30,10 +30,20 @@ pn_options = {
 }
 
 en_options = {
-  count          = 1
+  count = 2
   machine_type   = "n2-standard-2"
   boot_disk_size = 30
   # compute_disk_size = 100
+  # options = {
+  #   0:{
+  #     compute_disk_size = 1000
+  #     snapshot_id = "chaindata-full-kairos-20241231"
+  #   }
+  #   1:{
+  #     compute_disk_size = 1000
+  #     snapshot_id = "chaindata-full-kairos-20241231"
+  #   }
+  # }
 }
 
 monitor_options = {


### PR DESCRIPTION
# Description

- (1) support snapshot_id
```
en_options = {
  count = 2
  machine_type   = "n2-standard-2"
  boot_disk_size = 30
  compute_disk_size = 100
  snapshot_id = "chaindata-full-kairos-20241231"
}
```
- (2) make `compute_disk_size` works. The compute disk was not attached before. This PR attaches it. See `mount_disk.sh`
- (3) support specific options (but `count` cannot be specific option) 
```
en_options = {
  count = 2
  machine_type   = "n2-standard-2"
  boot_disk_size = 30
  options = {
    0:{
      compute_disk_size = 1000
      snapshot_id = "chaindata-full-kairos-20241231"
    }
    1:{
      compute_disk_size = 1000
      snapshot_id = "chaindata-full-kairos-20241231"
    }
  }
}
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
