### PR TITLE
gcp: add homi_extra_options

### DIFF
--- a/roles/en-scn-init/defaults/main.yml
+++ b/roles/en-scn-init/defaults/main.yml
@@ -50,4 +50,5 @@ kaia_port: 32323
 
 homi_output_dir: /opt/homi
 homi_default_options: ""
+homi_extra_options: ""
 homi_test_account_num: 2

--- a/roles/en-scn-init/tasks/init_scn.yml
+++ b/roles/en-scn-init/tasks/init_scn.yml
@@ -29,7 +29,7 @@
 
 - name: "Generate SCN data & genesis.json by Homi"
   become: yes
-  command: homi setup --gen-type local {{ homi_default_options }} --test-num {{ homi_test_account_num }} --cn-num {{ groups.scn|length }} --chainID {{ kaia_service_chain_id }} --network-id {{ kaia_service_network_id }} --p2p-port {{ kaia_conf.PORT }} -o {{ homi_results_dir }}
+  command: homi setup --gen-type local {{ homi_default_options }} {{ homi_extra_options }} --test-num {{ homi_test_account_num }} --cn-num {{ groups.scn|length }} --chainID {{ kaia_service_chain_id }} --network-id {{ kaia_service_network_id }} --p2p-port {{ kaia_conf.PORT }} -o {{ homi_results_dir }}
   when: 
     - not check_nodekey_file.stat.exists
     - '"bridge" in group_names'

--- a/roles/local-init/defaults/main.yml
+++ b/roles/local-init/defaults/main.yml
@@ -1,5 +1,6 @@
 homi_bin: "{{ bin_dir }}/homi"
 homi_default_options: ""
+homi_extra_options: ""
 homi_test_account_num: 16
 
 force_create_genesis: False

--- a/roles/local-init/tasks/genesis.yml
+++ b/roles/local-init/tasks/genesis.yml
@@ -8,7 +8,7 @@
 
 - name: "Generate {{ ctx.type }} data & genesis.json by Homi"
   shell: |
-    {{ homi_bin }} setup {{ homi_default_options }} --test-num {{ homi_test_account_num }} --cn-num {{ ctx.num }} --chainID {{ kaia_network_id }} --network-id {{ kaia_network_id }} -o {{ homi_output_dir }}/{{ ctx.type }} local
+    {{ homi_bin }} setup {{ homi_default_options }} {{ homi_extra_options }} --test-num {{ homi_test_account_num }} --cn-num {{ ctx.num }} --chainID {{ kaia_network_id }} --network-id {{ kaia_network_id }} -o {{ homi_output_dir }}/{{ ctx.type }} local
   tags:
   - localhost
   when:

--- a/terraform/gcp/private-layer1/ansible-inventory.tf
+++ b/terraform/gcp/private-layer1/ansible-inventory.tf
@@ -21,6 +21,7 @@ locals {
       kaia_num_en       = var.en_options.count
       kaia_network_id   = var.deploy_options.kaia_network_id
       kaia_chain_id     = var.deploy_options.kaia_chain_id
+      homi_extra_options = try(var.deploy_options.homi_extra_options, "")
     }
   )
 }

--- a/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
+++ b/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
@@ -17,3 +17,6 @@ kaia_num_en: ${kaia_num_en}
 # Network configuration
 kaia_network_id: ${kaia_network_id}
 kaia_chain_id: ${kaia_chain_id}
+
+# Homi extra options
+homi_extra_options: "${homi_extra_options}"

--- a/terraform/gcp/private-layer1/terraform.tfvars
+++ b/terraform/gcp/private-layer1/terraform.tfvars
@@ -13,6 +13,7 @@ deploy_options = {
   kaia_build_docker_base_image = "kaiachain/build_base:latest"
   kaia_network_id = 9999
   kaia_chain_id   = 9999
+  # homi_extra_options = ""
 }
 
 cn_options = {


### PR DESCRIPTION
# Description

This PR adds homi_extra_options at ansible. It is enabled at gcp.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
