### PR TITLE
Add jsexec script

### DIFF
--- a/local-deploy/10_jsexec.sh
+++ b/local-deploy/10_jsexec.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+binary=${1}${2}/bin/k${1}
+url=${1}${2}/data/klay.ipc
+js_command=$3
+if [ "$4" = "ws" ]; then
+  WS_PORT=$(sed -n 's/^WS_PORT=\([0-9]*\)$/\1/p' ${1}${2}/conf/k${1}d.conf)
+  url=ws://localhost:$WS_PORT
+elif [ "$4" = "rpc" ]; then
+  RPC_PORT=$(sed -n 's/^RPC_PORT=\([0-9]*\)$/\1/p' ${1}${2}/conf/k${1}d.conf)
+  url=http://localhost:$RPC_PORT
+elif [ $# -eq 1 ]; then
+  binary=cn1/bin/kcn
+  url=cn1/data/klay.ipc
+fi
+
+$binary --exec $js_command attach $url


### PR DESCRIPTION
# Description

10_jsexec.sh provides a single non-interactive js execution.
`./10_jsexec.sh $NODE_TYPE $NODE_ID $JS_COMMAND`

e.g)
```
./10_jsexec.sh cn 1 "kaia.blockNumber"
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
