### PR TITLE
local-deploy: Add auction rpc to cn

### DIFF
--- a/local-deploy/0_kaia_setup.sh
+++ b/local-deploy/0_kaia_setup.sh
@@ -50,6 +50,8 @@ modifyNNData()
       echo "" >> conf/pwd.txt
       # set REWARDBASE and unlock at kcnd.conf
       sed -i.bak "s/REWARDBASE=.*/REWARDBASE=\""`cat ../homi-output/keys/reward$num`"\"/g" $CONF_DIR
+      # set all APIs including auction to RPC_API
+      sed -i.bak "s/RPC_API=.*/RPC_API=\"admin,debug,kaia,miner,net,personal,rpc,txpool,web3,eth,istanbul,governance,auction\"/g" $CONF_DIR
       # set proper port number at static-nodes.json
       sed -i.bak $((num+1))"s/:"$((32323+PORT_BASE+num-1))"/:"$PORT"/g" ../homi-output/scripts/static-nodes.json
     elif [ $NODE_TYPE = "pn" ]; then


### PR DESCRIPTION
# Description

When launching the network with local-deploy, enable auction rpc.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Public Cloud:
* OS verson:
* Kaia version:
* Ansible version:
* Terraform version:

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
