### PR TITLE
Allow multiple git URL and branch

### DIFF
--- a/roles/local-build/tasks/main.yml
+++ b/roles/local-build/tasks/main.yml
@@ -1,92 +1,90 @@
 ---
+- name: Set build variables
+  set_fact:
+    git_url: "{{ deploy_options.kaia_build_remote_git_url | default(kaia_build_remote_git_url) }}"
+    git_branch: "{{ deploy_options.kaia_build_remote_git_branch | default(kaia_build_remote_git_branch) }}"
+
+- name: Calculate total builds
+  set_fact:
+    total_builds: "{{ [git_url | length if git_url is iterable and git_url is not string else 1, git_branch | length if git_branch is iterable and git_branch is not string else 1] | max }}"
+
 - name: Build - Check compiled binary
   ansible.builtin.stat:
-    path: "{{ kaia_build_check_file_path }}"
-  register: kaia_build_check_file_stat
-
-- name: Build - Check skipping compile
-  ansible.builtin.set_fact:
-    kaia_build_required: True
-  when:
-    - kaia_build_check_file_stat.stat.exists == False or 
-      kaia_build_skip_if_exists == False
+    path: "{{ kaia_build_check_file_path }}-{{ item }}"
+  register: kaia_build_check_file_stats
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Clean the old directory
   ansible.builtin.file:
     state: absent
-    path: "{{ kaia_build_dir }}"
-  when:
-    - kaia_build_required
+    path: "{{ kaia_build_dir }}-{{ item }}"
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Git checkout
   ansible.builtin.git:
-    repo: "{{ kaia_build_remote_git_url }}"
-    dest: "{{ kaia_build_dir }}"
-    version: "{{ kaia_build_remote_git_branch }}"
-  when:
-    - kaia_build_required
+    repo: "{{ git_url[item] if git_url is iterable and git_url is not string else git_url }}"
+    dest: "{{ kaia_build_dir }}-{{ item }}"
+    version: "{{ git_branch[item] if git_branch is iterable and git_branch is not string else git_branch }}"
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Compile kaia binary
   ansible.builtin.command: |
-    docker build --build-arg KLAYTN_STATIC_LINK=1 --build-arg DOCKER_BASE_IMAGE={{ kaia_build_docker_base_image }} -t {{ kaia_build_docker_builder_image }} --output output .
+    docker build --build-arg KLAYTN_STATIC_LINK=1 --build-arg DOCKER_BASE_IMAGE={{ kaia_build_docker_base_image }} -t {{ kaia_build_docker_builder_image }}-{{ item }} --output output .
   args:
-    chdir: "{{ kaia_build_dir }}"
+    chdir: "{{ kaia_build_dir }}-{{ item }}"
   environment:
     DOCKER_BUILDKIT: 1
-  when:
-    - kaia_build_required
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Compile homi binary locally
   ansible.builtin.command: |
     make homi
   args:
-    chdir: "{{ kaia_build_dir }}"
-  when:
-    - kaia_build_required
+    chdir: "{{ kaia_build_dir }}-{{ item }}"
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
+
+- name: Build - Create bin directory
+  ansible.builtin.file:
+    path: "{{ bin_dir }}-{{ item }}"
+    state: directory
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Copy homi binary
   ansible.builtin.copy:
-    dest: "{{ bin_dir }}/homi"
-    src: "{{ kaia_build_dir }}/build/bin/homi"
+    dest: "{{ bin_dir }}-{{ item }}/homi"
+    src: "{{ kaia_build_dir }}-{{ item }}/output/klaytn-docker-pkg/bin/homi"
     mode: preserve
-  when:
-    - kaia_build_required
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"
 
 - name: Build - Copy kaia binary files
   ansible.builtin.copy:
-    dest: "{{ bin_dir }}"
-    src: "{{ kaia_build_dir }}/output/klaytn-docker-pkg/bin/{{ item }}"
+    dest: "{{ bin_dir }}-{{ item[0] }}"
+    src: "{{ kaia_build_dir }}-{{ item[0] }}/output/klaytn-docker-pkg/bin/{{ item[1] }}"
     mode: preserve
-  loop:
-    - kbn
-    - kcn
-    - kpn
-    - ken
-    - kscn
-    - kspn
-    - ksen
-  when:
-    - kaia_build_required
+  when: not kaia_build_check_file_stats.results[item[0]].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  with_nested:
+    - "{{ range(0, total_builds | int) | list }}"
+    - ['kbn', 'kcn', 'kpn', 'ken', 'kscn', 'kspn', 'ksen']
 
 - name: Build - Copy kaia init.d script files
   ansible.builtin.copy:
-    dest: "{{ bin_dir }}"
-    src: "{{ kaia_build_dir }}/build/rpm/etc/init.d/{{ item }}"
+    dest: "{{ bin_dir }}-{{ item[0] }}"
+    src: "{{ kaia_build_dir }}-{{ item[0] }}/build/rpm/etc/init.d/{{ item[1] }}"
     mode: preserve
-  loop:
-    - kbnd
-    - kcnd
-    - kpnd
-    - kend
-    - kscnd
-    - kspnd
-    - ksend
-  when:
-    - kaia_build_required
+  when: not kaia_build_check_file_stats.results[item[0]].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  with_nested:
+    - "{{ range(0, total_builds | int) | list }}"
+    - ['kbnd', 'kcnd', 'kpnd', 'kend', 'kscnd', 'kspnd', 'ksend']
 
 - name: Build - Creating an empty file for checking
   ansible.builtin.file:
-    path: "{{ kaia_build_check_file_path }}"
+    path: "{{ kaia_build_check_file_path }}-{{ item }}"
     state: touch
-  when:
-    - kaia_build_required
+  when: not kaia_build_check_file_stats.results[item].stat.exists or not kaia_build_skip_if_exists or kaia_build_required
+  loop: "{{ range(0, total_builds | int) | list }}"

--- a/roles/node-init/tasks/install_build.yml
+++ b/roles/node-init/tasks/install_build.yml
@@ -6,17 +6,29 @@
     state: present
   when: ansible_os_family == "RedHat"
 
+- name: "Extract instance index from hostname"
+  set_fact:
+    instance_index: "{{ inventory_hostname | regex_replace('.*[a-z](\\d+)', '\\1') | int - 1 if inventory_hostname | regex_search('[a-z]\\d+$') else 0 }}"
+
+- name: "Calculate build count"
+  set_fact:
+    build_count: "{{ (deploy_options.kaia_build_remote_git_url | default(kaia_build_remote_git_url) | length) if (deploy_options.kaia_build_remote_git_url | default(kaia_build_remote_git_url)) is iterable and (deploy_options.kaia_build_remote_git_url | default(kaia_build_remote_git_url)) is not string else 1 }}"
+
+- name: "Set instance bin directory"
+  set_fact:
+    instance_bin_dir: "{{ bin_dir }}-{{ instance_index | int % build_count | int }}"
+
 - name: "Installation - Copy kaia binary"
   become: yes
   copy:
-    src: "{{ bin_dir }}/{{ kaia_binary_name }}"
+    src: "{{ instance_bin_dir }}/{{ kaia_binary_name }}"
     dest: "/bin/{{ kaia_binary_name }}"
     mode: preserve
 
 - name: "Installation - Copy kaia init.d script"
   become: yes
   copy:
-    src: "{{ bin_dir }}/{{ kaia_daemon_name }}"
+    src: "{{ instance_bin_dir }}/{{ kaia_daemon_name }}"
     dest: "/etc/init.d/{{ kaia_daemon_name }}"
     mode: preserve
 

--- a/terraform/gcp/private-layer1/ansible-inventory.tf
+++ b/terraform/gcp/private-layer1/ansible-inventory.tf
@@ -16,8 +16,6 @@ locals {
       kaia_install_mode = var.deploy_options.kaia_install_mode
       kaia_version      = try(var.deploy_options.kaia_version, "")
       kaia_build_docker_base_image = var.deploy_options.kaia_build_docker_base_image
-      kaia_build_remote_git_url = try(var.deploy_options.kaia_build_remote_git_url, "git@github.com:kaiachain/kaia.git")
-      kaia_build_remote_git_branch = try(var.deploy_options.kaia_build_remote_git_branch, "dev")
       kaia_num_cn       = var.cn_options.count
       kaia_num_pn       = var.pn_options.count
       kaia_num_en       = var.en_options.count

--- a/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
+++ b/terraform/gcp/private-layer1/templates/groupvarsall.tftpl
@@ -11,10 +11,6 @@ kaia_version: ${kaia_version}
 # Docker build settings
 kaia_build_docker_base_image: ${kaia_build_docker_base_image}
 
-# Git build settings
-kaia_build_remote_git_url: ${kaia_build_remote_git_url}
-kaia_build_remote_git_branch: ${kaia_build_remote_git_branch}
-
 # Node counts
 kaia_num_cn: ${kaia_num_cn}
 kaia_num_pn: ${kaia_num_pn}

--- a/terraform/gcp/private-layer1/terraform.tfvars
+++ b/terraform/gcp/private-layer1/terraform.tfvars
@@ -19,7 +19,9 @@ deploy_options = {
   kaia_version = "v1.0.3"
   kaia_build_docker_base_image = "kaiachain/build_base:latest"
   #kaia_build_remote_git_url = "git@github.com:kaiachain/kaia.git"
-  #kaia_build_remote_git_branch = "dev"
+  # You can specify multiple repos
+  #kaia_build_remote_git_url = ["git@github.com:kaiachain/kaia.git", "git@github.com:kaiachain/kaia.git"]
+  #kaia_build_remote_git_branch = "dev" # This also supports multiple branch names with array
   #kaia_network = "kairos"
   kaia_network_id = 9999
   kaia_chain_id   = 9999


### PR DESCRIPTION
# Description

This PR adds feature to allow multiple git URL and branch.
- The user could specify only one URL and branch
   ```
   kaia_build_remote_git_url = "git@github.com:kaiachain/kaia.git"
   kaia_build_remote_git_branch = "dev"
   ```
- Or the user could specify multiple git URL and branch using array
   ```
   kaia_build_remote_git_url = ["git@github.com:kaiachain/kaia.git", "git@github.com:myfork/kaia.git"]
   kaia_build_remote_git_branch = ["dev", "my-feature-branch"]
   ```

This allows the user to see the differences of the metrics in a single Grafana dashboard.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**: private-layer1
* Public Cloud: GCP
* OS verson: macOS 15.6
* Kaia version: v2.1.0
* Ansible version: 2.18.6
* Terraform version: v1.7.5

Also tested with [kaia-deploy-helper](https://github.com/kaiachain/kaia-deploy-helper) sync_test and load_test.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
